### PR TITLE
Make video

### DIFF
--- a/vivarium_multibody/composites/lattice.py
+++ b/vivarium_multibody/composites/lattice.py
@@ -22,7 +22,7 @@ from vivarium_multibody.composites.grow_divide import (
 from vivarium_multibody.plots.snapshots import (
     format_snapshot_data, get_agent_ids, plot_snapshots,
     DEFAULT_SV)
-from vivarium_multibody.plots.snapshots_video import make_video
+
 
 NAME = 'lattice_environment'
 
@@ -263,13 +263,6 @@ def main():
         out_dir=out_dir,
         filename=f"lattice_snapshots{'_exchange' if args.exchange else ''}")
 
-    # make video
-    make_video(
-        data,
-        bounds,
-        step=60,
-        out_dir=out_dir,
-        filename=f"lattice{'_exchange' if args.exchange else ''}_video")
 
 
 if __name__ == '__main__':

--- a/vivarium_multibody/composites/lattice.py
+++ b/vivarium_multibody/composites/lattice.py
@@ -139,6 +139,8 @@ def test_lattice(
         bounds=[25, 25],
         n_bins=None,
         initial_field=None,
+        growth_rate=0.05,  # fast growth
+        growth_noise=5e-4,
 ):
     # lattice configuration
     lattice_config_kwargs = {
@@ -159,8 +161,8 @@ def test_lattice(
     # agent configuration
     agent_config = {
         'growth': {
-            'growth_rate': 0.05,  # 0.006 very fast growth
-            'default_growth_noise': 5e-4},
+            'growth_rate': growth_rate,
+            'default_growth_noise': growth_noise},
         'divide_condition': {
             'threshold': 2500 * units.fg}}
     exchange_config = {

--- a/vivarium_multibody/plots/snapshots.py
+++ b/vivarium_multibody/plots/snapshots.py
@@ -741,15 +741,19 @@ def get_tag_ranges(agents, tagged_molecules, time_indices, convert_to_concs, tag
     return tag_ranges, tag_colors
 
 
+
 def make_tags_figure(
         agents,
         bounds,
         time_indices,
         snapshot_times,
+        tag_ranges=None,
+        tag_colors=None,
         n_snapshots=6,
         scale_bar_length=1,
         scale_bar_color='black',
         show_timeline=True,
+        show_colorbar=True,
         time_unit='s',
         tagged_molecules=None,
         out_dir=False,
@@ -764,7 +768,6 @@ def make_tags_figure(
         convert_to_concs=True,
         membrane_width=0.1,
         membrane_color=None,
-        tag_colors=None,
 ):
     '''Plot snapshots of the simulation over time
 
@@ -814,12 +817,12 @@ def make_tags_figure(
     tagged_molecules = tagged_molecules or []
     if tagged_molecules == []:
         raise ValueError('At least one molecule must be tagged.')
+    if not tag_ranges:
+        tag_ranges, tag_colors = get_tag_ranges(
+            agents, tagged_molecules, time_indices, convert_to_concs, tag_colors)
 
     # get data
     edge_length_x, edge_length_y = bounds
-
-    tag_ranges, tag_colors = get_tag_ranges(
-        agents, tagged_molecules, time_indices, convert_to_concs, tag_colors)
 
     # make the figure
     n_rows = len(tagged_molecules)
@@ -879,7 +882,7 @@ def make_tags_figure(
                     None, membrane_width, membrane_color)
 
             # colorbar in new column after final snapshot
-            if col_idx == n_snapshots - 1:
+            if col_idx == n_snapshots - 1 and show_colorbar:
                 cbar_col = col_idx + 1
                 ax = fig.add_subplot(grid[row_idx, cbar_col])
                 if row_idx == 0:

--- a/vivarium_multibody/plots/snapshots.py
+++ b/vivarium_multibody/plots/snapshots.py
@@ -749,6 +749,7 @@ def make_tags_figure(
         snapshot_times,
         tag_ranges=None,
         tag_colors=None,
+        agent_colors=None,
         n_snapshots=6,
         scale_bar_length=1,
         scale_bar_color='black',
@@ -812,6 +813,7 @@ def make_tags_figure(
     '''
 
     membrane_color = membrane_color or [1, 1, 1]
+    agent_colors = agent_colors or {}
     tag_colors = tag_colors or {}
     tag_path_name_map = tag_path_name_map or {}
     tagged_molecules = tagged_molecules or []
@@ -873,6 +875,7 @@ def make_tags_figure(
 
                 agent_tag_colors[agent_id] = agent_color
 
+            agent_tag_colors.update(agent_colors)
             plot_agents(ax, agents[time], agent_tag_colors, agent_shape,
                     None, membrane_width, membrane_color)
 

--- a/vivarium_multibody/plots/snapshots.py
+++ b/vivarium_multibody/plots/snapshots.py
@@ -840,8 +840,6 @@ def make_tags_figure(
 
     # plot tags
     for row_idx, tag_id in enumerate(tag_ranges.keys()):
-        used_agent_colors = []
-        concentrations = []
         for col_idx, (time_idx, time) in enumerate(
             zip(time_indices, snapshot_times)
         ):
@@ -868,11 +866,8 @@ def make_tags_figure(
                     volume = agent_data.get('boundary', {}).get('volume', 0)
                     level = level / volume if volume else 0
                 if min_tag != max_tag:
-                    concentrations.append(level)
                     intensity = (level - min_tag)/ (max_tag - min_tag)
                     agent_color = tag_h, tag_s, intensity
-                    agent_rgb = matplotlib.colors.hsv_to_rgb(agent_color)
-                    used_agent_colors.append(agent_rgb)
                 else:
                     agent_color = tag_h, tag_s, 0
 
@@ -893,17 +888,14 @@ def make_tags_figure(
                     continue
                 divider = make_axes_locatable(ax)
                 cax = divider.append_axes("left", size="5%", pad=0.0)
-                norm = matplotlib.colors.Normalize(
-                    vmin=min_tag, vmax=max_tag)
-                # Sort colors and concentrations by concentration
-                sorted_idx = np.argsort(concentrations)
+                norm = matplotlib.colors.Normalize(vmin=min_tag, vmax=max_tag)
+                # make colormap
+                min_color = tag_h, tag_s, 0
+                max_color = tag_h, tag_s, 1
+                min_rgb = matplotlib.colors.hsv_to_rgb(min_color)
+                max_rgb = matplotlib.colors.hsv_to_rgb(max_color)
                 cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
-                    'row_{}'.format(row_idx),
-                    [
-                        np.array(used_agent_colors)[sorted_idx][0],
-                        np.array(used_agent_colors)[sorted_idx][-1],
-                    ],
-                )
+                    'row_{}'.format(row_idx), [np.array(min_rgb), np.array(max_rgb)])
                 mappable = matplotlib.cm.ScalarMappable(norm, cmap)
                 fig.colorbar(mappable, cax=cax, format=f'%.{colorbar_decimals}f')
 

--- a/vivarium_multibody/plots/snapshots_video.py
+++ b/vivarium_multibody/plots/snapshots_video.py
@@ -46,7 +46,6 @@ def make_snapshot_function(
             bounds=bounds,
             default_font_size=12,
             plot_width=7,
-            show_timeline=False,
             scale_bar_length=0,
             **kwargs)
         return fig
@@ -93,9 +92,7 @@ def make_tags_function(
             bounds=bounds,
             default_font_size=12,
             plot_width=7,
-            show_timeline=False,
             scale_bar_length=0,
-            show_colorbar=False,
             **kwargs)
         return fig
 
@@ -166,16 +163,17 @@ def make_video(
 #         t_index=widgets.IntSlider(min=0, max=time_index_range, step=2, value=0))
 
 
-def main(total_time=2000, step=60):
+def main(total_time=2000, step=60, exchange=False):
     out_dir = os.path.join(TEST_OUT_DIR, 'snapshots_video')
     os.makedirs(out_dir, exist_ok=True)
 
     # GrowDivide agents
-    bounds = [25, 25]
+    bounds = [30, 30]
     n_bins = [20, 20]
     initial_field = np.zeros((n_bins[0], n_bins[1]))
     initial_field[:, -1] = 100
     data = test_lattice(
+        exchange=exchange,
         n_agents=3,
         total_time=total_time,
         growth_noise=1e-3,
@@ -208,5 +206,5 @@ def main(total_time=2000, step=60):
 
 
 if __name__ == '__main__':
-    main(6000)
+    main(total_time=3000, exchange=False)
 


### PR DESCRIPTION
This PR introduces the new function `make_video` in the plot file `snapshots_video.py`. It will take a simulation output and make a video in the style of a snapshots plot. It works from both snapshot and tag plot, and there is the beginning of functionality to highlight agents and include a video of their timeseries.  I am merging it before fully complete so that it can be used in a separate project.