### PR TITLE
Fix snapshots mu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/vivarium_multibody.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-multibody',
-    version='0.0.15',
+    version='0.0.16',
     packages=[
         'vivarium_multibody',
         'vivarium_multibody.plots',

--- a/vivarium_multibody/plots/snapshots.py
+++ b/vivarium_multibody/plots/snapshots.py
@@ -635,7 +635,7 @@ def make_snapshots_figure(
                 if col_idx == 0 and scale_bar_length:
                     scale_bar = anchored_artists.AnchoredSizeBar(
                         ax.transData, scale_bar_length,
-                        f'${scale_bar_length} \mu m$', 'lower left',
+                        f'{scale_bar_length} μm', 'lower left',
                         color=scale_bar_color,
                         frameon=False,
                         sep=scale_bar_length,
@@ -668,7 +668,7 @@ def make_snapshots_figure(
             if col_idx == 0 and scale_bar_length:
                 scale_bar = anchored_artists.AnchoredSizeBar(
                     ax.transData, scale_bar_length,
-                    f'${scale_bar_length} \\mu m$', 'lower left',
+                    f'{scale_bar_length} μm', 'lower left',
                     color=scale_bar_color,
                     frameon=False,
                     sep=scale_bar_length,
@@ -906,7 +906,7 @@ def make_tags_figure(
             if col_idx == 0 and scale_bar_length:
                 scale_bar = anchored_artists.AnchoredSizeBar(
                     ax.transData, scale_bar_length,
-                    f'${scale_bar_length} \\mu m$', 'lower left',
+                    f'{scale_bar_length} μm', 'lower left',
                     color=scale_bar_color,
                     frameon=False,
                     sep=scale_bar_length,


### PR DESCRIPTION
I was having trouble getting matplotlib to interpret `\\mu` with LaTeX, so I just used the unicode character `µ` instead.